### PR TITLE
Adds presto support to metadata ingestion

### DIFF
--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -93,15 +93,20 @@ def produce_dataset_mce(mce, kafka_config, producer):
     producer.produce(topic=kafka_config.kafka_topic, key=mce['proposedSnapshot'][1]['urn'], value=mce)
 
 
-def run(url, options, platform, schema_blacklist = None, kafka_config = KafkaConfig()):
+def run(url, options, platform, extra_kafka_conf = None, schema_blacklist = None, kafka_config = KafkaConfig()):
+    extra_kafka_conf = extra_kafka_conf or {}
     schema_blacklist = schema_blacklist or []
 
     engine = create_engine(url, **options)
 
-    # avro producer
-    conf = {'bootstrap.servers': kafka_config.bootstrap_server,
-            'on_delivery': delivery_report,
-            'schema.registry.url': kafka_config.schema_registry}
+    # Avro producer kafka configs
+    conf = {
+      'bootstrap.servers': kafka_config.bootstrap_server,
+      'on_delivery': delivery_report,
+      'schema.registry.url': kafka_config.schema_registry,
+      **extra_kafka_conf
+    }
+
     key_schema = avro.loads('{"type": "string"}')
     record_schema = avro.load(kafka_config.avsc_path)
     producer = AvroProducer(conf, default_key_schema=key_schema, default_value_schema=record_schema)

--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -63,7 +63,7 @@ def build_dataset_mce(platform, dataset_name, columns):
         "created": { "time": sys_time, "actor": actor },
         "lastModified": { "time":sys_time, "actor": actor },
         "hash": "",
-        "platformSchema": { "tableSchema": "" },
+        "platformSchema": { "tableSchema": "Table DDL goes here" },
         "fields": fields
     }
 
@@ -86,10 +86,19 @@ def delivery_report(err, msg):
         print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
 
 
-def produce_dataset_mce(mce, kafka_config):
+def produce_dataset_mce(mce, kafka_config, producer):
     """
     Produces a MetadataChangeEvent to Kafka
     """
+    producer.produce(topic=kafka_config.kafka_topic, key=mce['proposedSnapshot'][1]['urn'], value=mce)
+
+
+def run(url, options, platform, schema_blacklist = None, kafka_config = KafkaConfig()):
+    schema_blacklist = schema_blacklist or []
+
+    engine = create_engine(url, **options)
+
+    # avro producer
     conf = {'bootstrap.servers': kafka_config.bootstrap_server,
             'on_delivery': delivery_report,
             'schema.registry.url': kafka_config.schema_registry}
@@ -97,15 +106,15 @@ def produce_dataset_mce(mce, kafka_config):
     record_schema = avro.load(kafka_config.avsc_path)
     producer = AvroProducer(conf, default_key_schema=key_schema, default_value_schema=record_schema)
 
-    producer.produce(topic=kafka_config.kafka_topic, key=mce['proposedSnapshot'][1]['urn'], value=mce)
-    producer.flush()
-
-
-def run(url, options, platform, kafka_config = KafkaConfig()):
-    engine = create_engine(url, **options)
     inspector = reflection.Inspector.from_engine(engine)
     for schema in inspector.get_schema_names():
+        if schema in schema_blacklist:
+            continue
+
         for table in inspector.get_table_names(schema):
+            print(f"Producing data for table: {schema}.{table}")
             columns = inspector.get_columns(table, schema)
             mce = build_dataset_mce(platform, f'{schema}.{table}', columns)
-            produce_dataset_mce(mce, kafka_config)
+            produce_dataset_mce(mce, kafka_config, producer)
+
+        producer.flush()

--- a/metadata-ingestion/sql-etl/common.txt
+++ b/metadata-ingestion/sql-etl/common.txt
@@ -1,3 +1,6 @@
 avro-python3==1.8.2
 confluent-kafka[avro]==1.4.0
 SQLAlchemy==1.3.17
+
+# backport for python 3.6, available in python >=3.7
+dataclasses

--- a/metadata-ingestion/sql-etl/postgres_etl.py
+++ b/metadata-ingestion/sql-etl/postgres_etl.py
@@ -3,7 +3,7 @@ from common import run
 # See https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg2 for more details
 URL = '' # e.g. postgresql+psycopg2://user:password@host:port
 OPTIONS = {"echo": True} # e.g. {"client_encoding": "utf8"}
-PLATFORM = 'postgresql'
+PLATFORM = 'redshift'
 SCHEMA_BLACKLIST = ["_fivetran_staging", "admin", "attribution_testing", "bdrupieski_dev", "brazetest_local", "granttest_segment_data_lake", "information_schema"]
 
 run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/postgres_etl.py
+++ b/metadata-ingestion/sql-etl/postgres_etl.py
@@ -2,7 +2,8 @@ from common import run
 
 # See https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg2 for more details
 URL = '' # e.g. postgresql+psycopg2://user:password@host:port
-OPTIONS = {} # e.g. {"client_encoding": "utf8"}
+OPTIONS = {"echo": True} # e.g. {"client_encoding": "utf8"}
 PLATFORM = 'postgresql'
+SCHEMA_BLACKLIST = ["_fivetran_staging", "admin", "attribution_testing", "bdrupieski_dev", "brazetest_local", "granttest_segment_data_lake", "information_schema"]
 
-run(URL, OPTIONS, PLATFORM)
+run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/postgres_etl.py
+++ b/metadata-ingestion/sql-etl/postgres_etl.py
@@ -4,6 +4,6 @@ from common import run
 URL = '' # e.g. postgresql+psycopg2://user:password@host:port
 OPTIONS = {"echo": True} # e.g. {"client_encoding": "utf8"}
 PLATFORM = 'redshift'
-SCHEMA_BLACKLIST = ["_fivetran_staging", "admin", "attribution_testing", "bdrupieski_dev", "brazetest_local", "granttest_segment_data_lake", "information_schema"]
+SCHEMA_BLACKLIST = ["_fivetran_staging", "admin", "attribution_testing", "bdrupieski_dev", "information_schema", "inventory_local", "maggiehays", "money_squad_test", "pipegen_local", "segment_local", "test_grant", "user_deliverability_local", "weather_local"]
 
 run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/postgres_etl.py
+++ b/metadata-ingestion/sql-etl/postgres_etl.py
@@ -6,4 +6,14 @@ OPTIONS = {"echo": True} # e.g. {"client_encoding": "utf8"}
 PLATFORM = 'redshift'
 SCHEMA_BLACKLIST = ["_fivetran_staging", "admin", "attribution_testing", "bdrupieski_dev", "information_schema", "inventory_local", "maggiehays", "money_squad_test", "pipegen_local", "segment_local", "test_grant", "user_deliverability_local", "weather_local"]
 
-run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)
+# Modify to use your cert files from aiven (no java keystores!)
+EXTRA_KAFKA_CONF = {
+  'bootstrap.servers': '',
+  'schema.registry.url': '',
+  'security.protocol': 'SSL',
+  'ssl.ca.location': '/Users/grant.nicholas/.kafka/data_stg/ca.pem',
+  'ssl.key.location': '/Users/grant.nicholas/.kafka/data_stg/service.key',
+  'ssl.certificate.location': '/Users/grant.nicholas/.kafka/data_stg/service.cert'
+}
+
+run(URL, OPTIONS, PLATFORM, EXTRA_KAFKA_CONF, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/presto_etl.py
+++ b/metadata-ingestion/sql-etl/presto_etl.py
@@ -6,4 +6,14 @@ OPTIONS = {"echo": True, "connect_args": {"protocol": "https"}}
 PLATFORM = 'presto'
 SCHEMA_BLACKLIST = ['brazetest_local', 'granttest_segment_data_lake', 'information_schema', 'presto_performance_testing', 'segment_local', 'segment_processed_local', 'spark_pipegen_local', 'yield_management_local', 'zack_test']
 
-run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)
+# Modify to use your cert files from aiven (no java keystores!)
+EXTRA_KAFKA_CONF = {
+  'bootstrap.servers': '',
+  'schema.registry.url': '',
+  'security.protocol': 'SSL',
+  'ssl.ca.location': '/Users/grant.nicholas/.kafka/data_stg/ca.pem',
+  'ssl.key.location': '/Users/grant.nicholas/.kafka/data_stg/service.key',
+  'ssl.certificate.location': '/Users/grant.nicholas/.kafka/data_stg/service.cert'
+}
+
+run(URL, OPTIONS, PLATFORM, EXTRA_KAFKA_CONF, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/presto_etl.py
+++ b/metadata-ingestion/sql-etl/presto_etl.py
@@ -4,6 +4,6 @@ from common import run
 URL = '' # e.g. presto://user:password@host:port
 OPTIONS = {"echo": True, "connect_args": {"protocol": "https"}}
 PLATFORM = 'presto'
-SCHEMA_BLACKLIST = []
+SCHEMA_BLACKLIST = ['brazetest_local', 'granttest_segment_data_lake', 'information_schema', 'presto_performance_testing', 'segment_local', 'segment_processed_local', 'spark_pipegen_local', 'yield_management_local', 'zack_test']
 
 run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/presto_etl.py
+++ b/metadata-ingestion/sql-etl/presto_etl.py
@@ -1,0 +1,9 @@
+from common import run
+
+# See https://github.com/dropbox/PyHive for more details
+URL = '' # e.g. presto://user:password@host:port
+OPTIONS = {"echo": True, "connect_args": {"protocol": "https"}}
+PLATFORM = 'presto'
+SCHEMA_BLACKLIST = []
+
+run(URL, OPTIONS, PLATFORM, SCHEMA_BLACKLIST)

--- a/metadata-ingestion/sql-etl/presto_etl.txt
+++ b/metadata-ingestion/sql-etl/presto_etl.txt
@@ -1,0 +1,1 @@
+pyhive[presto]


### PR DESCRIPTION
1. Fixes the bug with the metadata ingestion scripts so it actually shows schemas in the UI: https://github.com/linkedin/datahub/issues/1728
2. Adds presto support
3. Adds ability to blacklist schemas (so we do not ingest test schemas/etc)
4. Restructures the producer code to make it better (do not make a producer for every table, instead reuse the same producer)

@samatspothero @twessels-sh how do we feel about the acceptance criteria? Since the scope of the work changed a lot, I ran manual integration tests against the local docker compose setup but end to end "real" datahub integration is not ready to go yet. 