### PR TITLE
Handle scheduling deps vs data deps properly

### DIFF
--- a/metadata-ingestion/pipegen-ingestion/test_pipegen/segment_user_destination_distance.yaml
+++ b/metadata-ingestion/pipegen-ingestion/test_pipegen/segment_user_destination_distance.yaml
@@ -3,8 +3,9 @@ Name: segment_user_destination_distance
 Description: |
   This pipeline calculates the distance between a user's location and the map center at the max timestamp of each session
 TargetTableName: pg_segment_user_destination_distance
+SchedulingDependencies:
+- {"Source": "Presto", "Name": "pg_segment_tracks"}
 DataDependencies:
-- {"Source": "Presto", "Name": "hive_emr.pipegen.pg_segment_tracks"}
 - {"Source": "Presto", "Name": "hive.segment.tracks"}
 - {"Source": "Presto", "Name": "hive.segment_processed.user_location_neighborhoods"}
 - {"Source": "Presto", "Name": "hive.segment_processed.search_event_neighborhoods"}


### PR DESCRIPTION
One more time...

I ran this against all the pipegen jobs in your branch @samatspothero and they all work except one:
```
diff --git a/active_event_rates_summary.yaml b/active_event_rates_summary.yaml
index 5647fe7..032633f 100644
--- a/active_event_rates_summary.yaml
+++ b/active_event_rates_summary.yaml
@@ -6,7 +6,7 @@ TargetTableName: pg_active_event_rates_summary
 TargetTableRedshiftConstraints: distkey(parking_spot_id) sortkey(parking_spot_id)
 SchedulingDependencies:
 - Source: Redshift
-  Name: pipegen.pg_event_type_rollup_definitions
+  Name: pg_event_type_rollup_definitions
 DataDependencies:
 - Source: Redshift
   Name: sh_public.parking_spot
```

After changing that to remove the unnecessary `pipegen.` they all ran successfully. Can you do that in your branch @samatspothero ?